### PR TITLE
update golang image

### DIFF
--- a/report/Dockerfile
+++ b/report/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.8
+FROM golang:1.11
 MAINTAINER Pantheon Systems
 
 RUN apt-get update -y --fix-missing


### PR DESCRIPTION
Couldn't get the current `Dockerfile` to build due to some outdated repositories. Updating to `golang:1.11` fixed this issue.